### PR TITLE
Add MongoDB authentication layer

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -1,3 +1,5 @@
+using Microsoft.Maui.Storage;
+using Elecciones.Views;
 ﻿namespace Elecciones
 {
     public partial class App : Application
@@ -6,7 +8,15 @@
         {
             InitializeComponent();
 
-            MainPage = new NavigationPage(new MainPage());
+            var storedUser = Preferences.Get("username", null);
+            if (!string.IsNullOrEmpty(storedUser))
+            {
+                MainPage = new NavigationPage(new MainPage());
+            }
+            else
+            {
+                MainPage = new NavigationPage(new LoginPage());
+            }
         }
         protected override void OnStart()
         {

--- a/Elecciones.csproj
+++ b/Elecciones.csproj
@@ -66,8 +66,10 @@
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.5" />
 		<PackageReference Include="Microsoft.Maui.Controls" Version="$(MauiVersion)" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="$(MauiVersion)" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
-	</ItemGroup>
+                <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.1" />
+                <PackageReference Include="MongoDB.Driver" Version="*" />
+                <PackageReference Include="BCrypt.Net-Next" Version="*" />
+        </ItemGroup>
 
 	<ItemGroup>
 	  <MauiXaml Update="Views\ConfiguracionPage.xaml">
@@ -82,9 +84,12 @@
 	  <MauiXaml Update="Views\VotantesConfigPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
-	  <MauiXaml Update="Views\VotantesPage.xaml">
-	    <Generator>MSBuild:Compile</Generator>
-	  </MauiXaml>
-	</ItemGroup>
+          <MauiXaml Update="Views\VotantesPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+          <MauiXaml Update="Views\LoginPage.xaml">
+            <Generator>MSBuild:Compile</Generator>
+          </MauiXaml>
+        </ItemGroup>
 
 </Project>

--- a/MauiProgram.cs
+++ b/MauiProgram.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using CommunityToolkit.Mvvm;
 using CommunityToolkit.Maui;
+using Elecciones.Services;
 using System.Globalization;
 CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("es-AR");
 CultureInfo.DefaultThreadCurrentUICulture = new CultureInfo("es-AR");
@@ -16,12 +17,15 @@ namespace Elecciones
             var builder = MauiApp.CreateBuilder();
             builder
                 .UseMauiApp<App>()
-                .UseMauiCommunityToolkit() // Corrected method for CommunityToolkit.Maui  
+                .UseMauiCommunityToolkit() // Corrected method for CommunityToolkit.Maui
                 .ConfigureFonts(fonts =>
                 {
                     fonts.AddFont("OpenSans-Regular.ttf", "OpenSansRegular");
                     fonts.AddFont("OpenSans-Semibold.ttf", "OpenSansSemibold");
                 });
+
+            var connectionString = Environment.GetEnvironmentVariable("MONGODB_CONNECTION") ?? string.Empty;
+            builder.Services.AddSingleton<AuthService>(_ => new AuthService(connectionString));
 
 #if DEBUG
             builder.Logging.AddDebug();

--- a/Models/User.cs
+++ b/Models/User.cs
@@ -1,0 +1,13 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+public class User
+{
+    [BsonId]
+    [BsonRepresentation(BsonType.ObjectId)]
+    public string Id { get; set; }
+
+    public string Username { get; set; }
+
+    public string PasswordHash { get; set; }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Elecciones
+
+This application uses SQLite for election data and MongoDB for user authentication.
+
+## MongoDB setup
+
+Provide a MongoDB connection string using the `MONGODB_CONNECTION` environment variable before launching the app. The authentication service will use this string to connect and store users in the `elecciones` database.
+
+## Authentication
+
+Users are stored in MongoDB with passwords hashed using BCrypt. On first launch a login screen is presented. After a successful login the username is saved and the next time the app starts it navigates directly to the main page.

--- a/Services/AuthService.cs
+++ b/Services/AuthService.cs
@@ -1,0 +1,42 @@
+using MongoDB.Driver;
+using BCrypt.Net;
+
+public class AuthService
+{
+    private readonly IMongoCollection<User> _users;
+
+    public AuthService(string connectionString)
+    {
+        var client = new MongoClient(connectionString);
+        var database = client.GetDatabase("elecciones");
+        _users = database.GetCollection<User>("users");
+    }
+
+    public async Task<User?> GetUserAsync(string username)
+    {
+        return await _users.Find(u => u.Username == username).FirstOrDefaultAsync();
+    }
+
+    public async Task<bool> RegisterAsync(string username, string password)
+    {
+        var existing = await GetUserAsync(username);
+        if (existing != null)
+            return false;
+
+        var user = new User
+        {
+            Username = username,
+            PasswordHash = BCrypt.Net.BCrypt.HashPassword(password)
+        };
+        await _users.InsertOneAsync(user);
+        return true;
+    }
+
+    public async Task<User?> LoginAsync(string username, string password)
+    {
+        var user = await GetUserAsync(username);
+        if (user != null && BCrypt.Net.BCrypt.Verify(password, user.PasswordHash))
+            return user;
+        return null;
+    }
+}

--- a/Views/LoginPage.xaml
+++ b/Views/LoginPage.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Elecciones.Views.LoginPage"
+             Title="Login">
+    <VerticalStackLayout Padding="20" Spacing="15" VerticalOptions="Center">
+        <Entry x:Name="usernameEntry" Placeholder="Usuario" />
+        <Entry x:Name="passwordEntry" Placeholder="Contraseña" IsPassword="True" />
+        <Button Text="Iniciar sesión" Clicked="OnLoginClicked" />
+    </VerticalStackLayout>
+</ContentPage>

--- a/Views/LoginPage.xaml.cs
+++ b/Views/LoginPage.xaml.cs
@@ -1,0 +1,39 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Storage;
+using Elecciones.Services;
+
+namespace Elecciones.Views;
+
+public partial class LoginPage : ContentPage
+{
+    private readonly AuthService _authService;
+
+    public LoginPage()
+    {
+        InitializeComponent();
+        _authService = MauiApplication.Current.Services.GetService<AuthService>();
+    }
+
+    private async void OnLoginClicked(object sender, EventArgs e)
+    {
+        var username = usernameEntry.Text?.Trim();
+        var password = passwordEntry.Text;
+
+        if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password))
+        {
+            await DisplayAlert("Error", "Ingrese usuario y contraseña", "OK");
+            return;
+        }
+
+        var user = await _authService.LoginAsync(username, password);
+        if (user != null)
+        {
+            Preferences.Set("username", user.Username);
+            Application.Current.MainPage = new NavigationPage(new MainPage());
+        }
+        else
+        {
+            await DisplayAlert("Error", "Credenciales inválidas", "OK");
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add MongoDB and BCrypt packages
- create Mongo backed `AuthService`
- implement `User` model
- add login UI and hook it into startup
- document MongoDB connection string

## Testing
- `dotnet build Elecciones.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445e6f36e88329bdd72bfd9fe3fa95