### PR TITLE
Fix connection string usage

### DIFF
--- a/Services/AuthService.cs
+++ b/Services/AuthService.cs
@@ -9,7 +9,12 @@ namespace Elecciones.Services
 
         public AuthService(string connectionString)
         {
-            var client = new MongoClient(connectionString = "mongodb://localhost:27017");
+            if (string.IsNullOrWhiteSpace(connectionString))
+            {
+                connectionString = "mongodb://localhost:27017";
+            }
+
+            var client = new MongoClient(connectionString);
             var database = client.GetDatabase("elecciones");
             _users = database.GetCollection<User>("users");
         }


### PR DESCRIPTION
## Summary
- preserve incoming connection string in `AuthService`
- default to localhost if no connection string is passed

## Testing
- `dotnet build Elecciones.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449e2b5bd08329b34b6c8bacc7e938

## Summary by Sourcery

Fix connection string handling in AuthService to respect non-empty incoming strings and default to localhost otherwise

Bug Fixes:
- Preserve provided connection string instead of unconditionally overwriting it
- Default to mongodb://localhost:27017 when no connection string is supplied