### PR TITLE
Add DNI to user data

### DIFF
--- a/Models/User.cs
+++ b/Models/User.cs
@@ -9,5 +9,8 @@ public class User
 
     public string Username { get; set; }
 
+    [BsonElement("dni")]
+    public string Dni { get; set; }
+
     public string PasswordHash { get; set; }
 }

--- a/README.md
+++ b/README.md
@@ -9,3 +9,6 @@ Provide a MongoDB connection string using the `MONGODB_CONNECTION` environment v
 ## Authentication
 
 Users are stored in MongoDB with passwords hashed using BCrypt. On first launch a login screen is presented. After a successful login the username is saved and the next time the app starts it navigates directly to the main page.
+
+Each user document now includes a `Dni` property stored in the `dni` field.
+This value is collected during registration to uniquely identify the voter.

--- a/Services/AuthService.cs
+++ b/Services/AuthService.cs
@@ -19,7 +19,7 @@ namespace Elecciones.Services
             return await _users.Find(u => u.Username == username).FirstOrDefaultAsync();
         }
 
-        public async Task<bool> RegisterAsync(string username, string password)
+        public async Task<bool> RegisterAsync(string username, string password, string dni)
         {
             var existing = await GetUserAsync(username);
             if (existing != null)
@@ -28,7 +28,8 @@ namespace Elecciones.Services
             var user = new User
             {
                 Username = username,
-                PasswordHash = BCrypt.Net.BCrypt.HashPassword(password)
+                PasswordHash = BCrypt.Net.BCrypt.HashPassword(password),
+                Dni = dni
             };
             await _users.InsertOneAsync(user);
             return true;

--- a/Views/LoginPage.xaml
+++ b/Views/LoginPage.xaml
@@ -5,6 +5,7 @@
              Title="Login">
     <VerticalStackLayout Padding="20" Spacing="15" VerticalOptions="Center">
         <Entry x:Name="usernameEntry" Placeholder="Usuario" />
+        <Entry x:Name="dniEntry" Placeholder="DNI" />
         <Entry x:Name="passwordEntry" Placeholder="Contraseña" IsPassword="True" />
         <Button Text="Iniciar sesión" Clicked="OnLoginClicked" />
     </VerticalStackLayout>


### PR DESCRIPTION
## Summary
- store DNI value on `User`
- keep DNI when registering new users
- add DNI field to login page for future registration
- document the new property in README

## Testing
- `dotnet build Elecciones.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68449e3550748329b684de1ac557002f

## Summary by Sourcery

Add support for capturing and storing a user’s DNI through the registration flow, update the user model and UI to include the new field, and document the change in the README

New Features:
- Collect and store a DNI value when registering new users
- Add a DNI input field to the login/registration page

Documentation:
- Document the new Dni property in the README