### PR TITLE
Add registration and analysis screens

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,14 @@ Users are stored in MongoDB with passwords hashed using BCrypt. On first launch 
 
 Each user document now includes a `Dni` property stored in the `dni` field.
 This value is collected during registration to uniquely identify the voter.
+
+## Registration screen
+
+The app now contains a dedicated **RegisterPage** that collects username, DNI
+and password. New users are stored in MongoDB and, on success, the main page is
+shown immediately.
+
+## Voting analysis
+
+From the list of voters you can open an **Análisis** screen that displays the
+total number of voters, how many have voted and the percentage of participation.

--- a/Views/AnalisisPage.xaml
+++ b/Views/AnalisisPage.xaml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Elecciones.Views.AnalisisPage"
+             Title="Análisis">
+    <VerticalStackLayout Padding="20" Spacing="10">
+        <Label x:Name="totalLabel" FontSize="20" />
+        <Label x:Name="votaronLabel" FontSize="20" />
+        <Label x:Name="porcentajeLabel" FontSize="20" />
+    </VerticalStackLayout>
+</ContentPage>

--- a/Views/AnalisisPage.xaml.cs
+++ b/Views/AnalisisPage.xaml.cs
@@ -1,0 +1,16 @@
+using Microsoft.Maui.Controls;
+
+namespace Elecciones.Views;
+
+public partial class AnalisisPage : ContentPage
+{
+    public AnalisisPage(int total, int votaron)
+    {
+        InitializeComponent();
+
+        totalLabel.Text = $"Total de votantes: {total}";
+        votaronLabel.Text = $"Votaron: {votaron}";
+        double porcentaje = total > 0 ? votaron * 100.0 / total : 0;
+        porcentajeLabel.Text = $"Porcentaje: {porcentaje:F2}%";
+    }
+}

--- a/Views/LoginPage.xaml.cs
+++ b/Views/LoginPage.xaml.cs
@@ -39,27 +39,9 @@ public partial class LoginPage : ContentPage
         }
     }
 
-    private async void OnRegisterClicked(object sender, EventArgs e)
+
+    private async void OnNavigateRegister(object sender, EventArgs e)
     {
-        var username = usernameEntry.Text?.Trim();
-        var password = passwordEntry.Text;
-
-        if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password))
-        {
-            await DisplayAlert("Error", "Ingrese usuario y contraseña", "OK");
-            return;
-        }
-
-        var existing = await _authService.GetUserAsync(username);
-        if (existing == null)
-        {
-            await _authService.RegisterAsync(username, password);
-            Preferences.Set("username", username);
-            Application.Current.MainPage = new NavigationPage(new MainPage());
-        }
-        else
-        {
-            await DisplayAlert("Advertencia", "El usuario ya existe", "OK");
-        }
+        await Navigation.PushAsync(new RegisterPage());
     }
 }

--- a/Views/RegisterPage.xaml
+++ b/Views/RegisterPage.xaml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Elecciones.Views.LoginPage"
-             Title="Login">
+             x:Class="Elecciones.Views.RegisterPage"
+             Title="Registro">
     <VerticalStackLayout Padding="20" Spacing="15" VerticalOptions="Center">
         <Entry x:Name="usernameEntry" Placeholder="Usuario" />
+        <Entry x:Name="dniEntry" Placeholder="DNI" />
         <Entry x:Name="passwordEntry" Placeholder="Contraseña" IsPassword="True" />
-        <Button Text="Iniciar sesión" Clicked="OnLoginClicked" />
-        <Button Text="Registrarse" Clicked="OnNavigateRegister" />
+        <Button Text="Registrarse" Clicked="OnRegisterClicked" />
     </VerticalStackLayout>
 </ContentPage>

--- a/Views/RegisterPage.xaml.cs
+++ b/Views/RegisterPage.xaml.cs
@@ -1,0 +1,41 @@
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Storage;
+using Elecciones.Services;
+using Microsoft.Maui.ApplicationModel;
+
+namespace Elecciones.Views;
+
+public partial class RegisterPage : ContentPage
+{
+    private readonly AuthService _authService;
+
+    public RegisterPage()
+    {
+        InitializeComponent();
+        _authService = IPlatformApplication.Current?.Services?.GetService<AuthService>();
+    }
+
+    private async void OnRegisterClicked(object sender, EventArgs e)
+    {
+        var username = usernameEntry.Text?.Trim();
+        var dni = dniEntry.Text?.Trim();
+        var password = passwordEntry.Text;
+
+        if (string.IsNullOrEmpty(username) || string.IsNullOrEmpty(password) || string.IsNullOrEmpty(dni))
+        {
+            await DisplayAlert("Error", "Ingrese usuario, DNI y contraseña", "OK");
+            return;
+        }
+
+        var success = await _authService.RegisterAsync(username, password, dni);
+        if (success)
+        {
+            Preferences.Set("username", username);
+            Application.Current.MainPage = new NavigationPage(new MainPage());
+        }
+        else
+        {
+            await DisplayAlert("Advertencia", "El usuario ya existe", "OK");
+        }
+    }
+}

--- a/Views/VotantesPage.xaml.cs
+++ b/Views/VotantesPage.xaml.cs
@@ -31,13 +31,8 @@ public partial class VotantesPage : ContentPage
     {
         int total = votantes.Count;
         int votaron = votantes.Count(v => v.HaVotado);
-        double porcentaje = total > 0 ? (votaron * 100.0 / total) : 0;
 
-        await DisplayAlert("Estadísticas",
-            $"Total de votantes: {total}\n" +
-            $"Votaron: {votaron}\n" +
-            $"Porcentaje: {porcentaje:F2}%",
-            "OK");
+        await Navigation.PushAsync(new AnalisisPage(total, votaron));
     }
 
     private void OnBuscarChanged(object sender, TextChangedEventArgs e)


### PR DESCRIPTION
## Summary
- create `RegisterPage` for user sign up
- navigate from the login page to registration
- create `AnalisisPage` for voter statistics
- show analysis page from the voter list
- document usage of new screens in README

## Testing
- `dotnet build -bl` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844aa1b217c832995ad132c86d5cd9f

## Summary by Sourcery

Add dedicated registration and analysis pages, connect navigation flows, and update documentation accordingly

New Features:
- Introduce RegisterPage for new user registration
- Introduce AnalisisPage to display voter statistics

Enhancements:
- Wire LoginPage to navigate to RegisterPage instead of handling registration inline
- Update VotantesPage to navigate to AnalisisPage for showing statistics

Documentation:
- Document the registration and analysis screens in README